### PR TITLE
Remove the hardcoded IP address of the gogs server

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a small set of tools to test GoCD with pipelines as code.
 ```
  <config-repos>
     <config-repo pluginId="yaml.config.plugin" id="ots-pipeline-code">
-      <git url="http://172.25.0.3:3000/my-user/my-pipeline-code-repo.git" />
+      <git url="http://gocdplayground_gogs_1:3000/my-user/my-pipeline-code-repo.git" />
     </config-repo>
   </config-repos>
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is a small set of tools to test GoCD with pipelines as code.
 ```
  <config-repos>
     <config-repo pluginId="yaml.config.plugin" id="ots-pipeline-code">
-      <git url="http://gocdplayground_gogs_1:3000/my-user/my-pipeline-code-repo.git" />
+      <git url="http://gogs:3000/my-user/my-pipeline-code-repo.git" />
     </config-repo>
   </config-repos>
 ```


### PR DESCRIPTION
Subsequent execution of docker-compose may launch the gogs server with a different internal IP address, so we can't hardcode it in the GoCD configuration, but we should instead use the internal DNS names created by Docker.